### PR TITLE
Bugfixes for radialNetwork.js

### DIFF
--- a/inst/htmlwidgets/radialNetwork.js
+++ b/inst/htmlwidgets/radialNetwork.js
@@ -39,7 +39,12 @@ HTMLWidgets.widget({
     // JSON array with the d3Tree root data
 
     var s = d3.select(el).selectAll("svg");
-
+    
+    // when re-rendering the svg, the viewBox attribute set in the code below, will
+    // be affected by the previously set viewBox. This line ensures, that the 
+    // viewBox will always be calculated right. 
+    s.attr("viewBox", null);
+    
     // margin handling
     //   set our default margin to be 20
     //   will override with x.options.margin if provided
@@ -60,8 +65,9 @@ HTMLWidgets.widget({
       s.node().getBoundingClientRect().height - margin.top - margin.bottom
     );
 
+    //added Math.max(1, ...) to avoid NaN values when dealing with nodes of depth 0.
     tree.size([360, diameter/2])
-        .separation(function(a, b) { return (a.parent == b.parent ? 1 : 2) / a.depth; });
+        .separation(function(a, b) { return (a.parent == b.parent ? 1 : 2) / Math.max(1, a.depth); });
 
     // select the svg group element and remove existing children
     s.attr("pointer-events", "all").selectAll("*").remove();


### PR DESCRIPTION
Fixed 2 bugs:
1) Line 69:

"linear" networks (i.e. of type  a ----- b) weren't rendered correctly, due to a zero division. Inserted Math.max(1, ...) to fix this problem.

2) Line 46:

When re-rendering a network in the same parent, the svg viewBox, which ensures that all text labels are visible, was affected by the viewBox attribute before the re-rendering. Thus the viewBox attribute changed even if the content did not, and could even move the image out of bounds. By explicitly setting the viewBox attribute to null on initalization, this is now inhibited.
